### PR TITLE
chore(sync): enable label removal in sync config

### DIFF
--- a/.github/sync-config.yml
+++ b/.github/sync-config.yml
@@ -1,0 +1,7 @@
+---
+# Unified Sync Configuration
+# Enable label removal to keep labels in sync with central config
+
+sync:
+  labels:
+    allow_removal: true


### PR DESCRIPTION
Enable label removal in sync configuration to keep labels synchronized with the central organization configuration.

## Changes

- Add `.github/sync-config.yml` with `labels.allow_removal: true`

## Impact

Labels not defined in [`smykla-labs/.github`](https://github.com/smykla-labs/.github/blob/main/.github/labels.yml) will be automatically removed from this repository during label sync.

This ensures consistency across all organization repositories.