### PR TITLE
chore(sync): add schema reference to sync config

### DIFF
--- a/.github/sync-config.yml
+++ b/.github/sync-config.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/smykla-labs/.github/main/schemas/sync-config.schema.json
 ---
 # Unified Sync Configuration
 # Enable label removal to keep labels in sync with central config


### PR DESCRIPTION
## Motivation

Enable IDE validation and autocomplete for `.github/sync-config.yml` by referencing the JSON Schema from the central `.github` repository.

## Implementation information

- Add `yaml-language-server` schema directive at top of file

> Changelog: skip