### PR TITLE
fix(screen-recorder): address Copilot review

### DIFF
--- a/claude-code/skills/screen-recorder/screen_recorder/cli.py
+++ b/claude-code/skills/screen-recorder/screen_recorder/cli.py
@@ -279,7 +279,14 @@ def parse_preset(preset_str: str | None) -> PlatformPreset | None:
 
 
 def parse_capture_backend(backend_str: str | None):
-    """Parse capture backend string to enum."""
+    """Parse capture backend string to enum.
+
+    Args:
+        backend_str: Backend name string or None.
+
+    Returns:
+        CaptureBackend enum value.
+    """
     from .models import CaptureBackend
 
     if not backend_str:


### PR DESCRIPTION
## Summary

Addresses all 10 Copilot review comments from PR #21 (feat: add SCK video streaming).

## Motivation

PR #21 introduced ScreenCaptureKit video streaming with several code quality issues flagged by Copilot's automated review. These include magic numbers, missing error handling, inaccurate comments, and lack of test coverage. Addressing these improves maintainability and reliability.

## Implementation information

### Code Quality Improvements

- Extract magic numbers to named constants with documentation:
  - `RETINA_SCALE_FACTOR = 2` - Retina display scaling
  - `STREAM_START_WAIT_SECONDS = 0.5` - Stream initialization delay
  - `PIXEL_FORMAT_BGRA = 1111970369` - kCVPixelFormatType_32BGRA
  - `ASSET_WRITER_FINISH_TIMEOUT_SECONDS = 5.0` - Write completion timeout

- Improve `_VideoWriter.finish()` error handling:
  - Check if completion times out
  - Check for asset writer errors
  - Raise `CaptureError` with descriptive messages

- Fix window activation logic:
  - Skip `_handle_window_activation()` when using ScreenCaptureKit
  - SCK doesn't require window activation to capture content

- Update AUTO mode comment for accuracy:
  - Changed to "use SCK when available for non-fullscreen window recording"

- Expand `parse_capture_backend` docstring with Args/Returns sections

### Test Coverage

Added comprehensive tests for previously uncovered areas:

- `TestConstants` - Verify all named constants
- `TestSCStreamOutputHandler` - Handler initialization and creation
- `TestFindSCWindow` - Error paths when SCK unavailable
- `TestVideoWriterErrorHandling` - Setup and append error cases

### PyObjC Convention Note

The `self_` parameter naming in `_SCStreamOutputHandler` is intentional and follows PyObjC conventions for Objective-C protocol bridge methods.